### PR TITLE
update the pic upload limit of bigmodel from 200k to 2M

### DIFF
--- a/infrastructure/bigmodels/config.go
+++ b/infrastructure/bigmodels/config.go
@@ -21,11 +21,11 @@ func (cfg *Config) SetDefault() {
 	cfg.WuKong.setDefault()
 
 	if cfg.MaxPictureSizeToDescribe <= 0 {
-		cfg.MaxPictureSizeToDescribe = 200 << 10
+		cfg.MaxPictureSizeToDescribe = 2 << 20
 	}
 
 	if cfg.MaxPictureSizeToVQA <= 0 {
-		cfg.MaxPictureSizeToVQA = 200 << 10
+		cfg.MaxPictureSizeToVQA = 2 << 20
 	}
 }
 


### PR DESCRIPTION
update the pic upload limit of bigmodel from 200k to 2M。

- 在本地测试，2M的图片，速度在2s左右，可接受。
- 需测试真实场景的图片上传链路推理速度（多了一个图片传后端服务器的时间）。