### PR TITLE
fix: do not sync email while login

### DIFF
--- a/controller/login.go
+++ b/controller/login.go
@@ -117,12 +117,6 @@ func (ctl *LoginController) Login(ctx *gin.Context) {
 		if user, err = ctl.newUser(ctx, info); err != nil {
 			return
 		}
-	} else {
-		if user.Email != info.Email.Email() {
-			ctl.us.UpdateBasicInfo(
-				info.Name, userapp.UpdateUserBasicInfoCmd{Email: info.Email},
-			)
-		}
 	}
 
 	if err := ctl.newLogin(ctx, info); err != nil {


### PR DESCRIPTION
when we login with third-party way, xihe will update email from authing
It will make user's center of xihe show email but not register in gitlab 