### PR TITLE
update vqa and luojianet upload filepath

### DIFF
--- a/infrastructure/bigmodels/luojia.go
+++ b/infrastructure/bigmodels/luojia.go
@@ -37,7 +37,7 @@ func (s *service) LuoJiaUploadPicture(f io.Reader, user domain.Account) error {
 	return s.obs.createObject(
 		f,
 		s.luojiaInfo.bucket,
-		fmt.Sprintf("infer/%s/input.png", user.Account()),
+		fmt.Sprintf("luojianet/infer/%s/input.png", user.Account()),
 	)
 }
 

--- a/infrastructure/bigmodels/vqa.go
+++ b/infrastructure/bigmodels/vqa.go
@@ -94,5 +94,5 @@ func (s *service) Ask(q domain.Question, f string) (string, error) {
 }
 
 func (s *service) VQAUploadPicture(f io.Reader, user domain.Account, fileName string) error {
-	return s.obs.createObject(f, s.vqaInfo.bucket, filepath.Join(user.Account(), fileName))
+	return s.obs.createObject(f, s.vqaInfo.bucket, filepath.Join("vqa", user.Account(), fileName))
 }


### PR DESCRIPTION
1. 因为大模型资源由云星入口迁移到云联盟，需适配更改vqa和luojianet的上传路径
2. <mask>目前是基于之前的代码改的路径，建议后续加入配置文件中