### PR TITLE
[fix]fix vqa 503 question bug

### DIFF
--- a/bigmodel/infrastructure/bigmodels/vqa.go
+++ b/bigmodel/infrastructure/bigmodels/vqa.go
@@ -70,7 +70,7 @@ func (s *service) Ask(q domain.Question, f string) (string, error) {
 	}
 
 	opt := questionOpt{
-		Picture:  f,
+		Picture:  filepath.Join("vqa", f),
 		Question: q.Question(),
 	}
 

--- a/infrastructure/bigmodels/vqa.go
+++ b/infrastructure/bigmodels/vqa.go
@@ -60,7 +60,7 @@ func (s *service) Ask(q domain.Question, f string) (string, error) {
 	}
 
 	opt := questionOpt{
-		Picture:  f,
+		Picture:  filepath.Join("vqa", f),
 		Question: q.Question(),
 	}
 


### PR DESCRIPTION
干了什么？
1. 修复了推理image_path的bug

记得遗留
1. vqa和luojianet存在大量硬编码，更改一个上传路径，需要更改多处代码。